### PR TITLE
LinterとしてPEP8を入れる

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -15,7 +15,7 @@ jobs:
         id: autopep8
         uses: peter-evans/autopep8@v1.2.0
         with:
-          args: --exit-code --recursive --in-place --aggressive --aggressive .
+          args: --exit-code --recursive --aggressive --aggressive --diff .
 
       - name: Fail if autopep8 made changes
         if: steps.autopep8.outputs.exit-code == 2

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  lint:
+    name: run pep8 linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v2
+
+      - name: autopep8
+        id: autopep8
+        uses: peter-evans/autopep8@v1.2.0
+        with:
+          args: --exit-code --recursive --in-place --aggressive --aggressive .
+
+      - name: Fail if autopep8 made changes
+        if: steps.autopep8.outputs.exit-code == 2
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -32,3 +32,61 @@
  - ネオロック74 (akabeko3145.wav)
  - BPM == 145
 
+## 開発に際して
+このプロジェクト内にある全てのpythonスクリプトは [PEP8](https://pep8-ja.readthedocs.io/ja/latest/) に準拠したコーディングスタイルでLinterが走ってくれる。
+これはgithub action上でチェックされるので、github actionで全てのチェックを通さないとマージすることは出来ない。
+
+手元でgithub actionsが通るかどうかをチェックするためには [act](https://github.com/nektos/act) を使うと便利。
+
+macの場合は `brew install act` でインストールが可能。 `brew` が使うことが出来ない環境等では以下のコマンドでインストールすることができる。
+
+```
+$ curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+```
+
+※他のインストール方法等は公式のドキュメントを参照のこと
+
+### actを使ったgithub actionの確認
+actを使用する準備が出来たら act を使って実際にgithub actionsを手元で確認する。
+
+プロジェクトルートで 
+
+```
+$ act
+```
+
+コマンドを実行すると、自動でgithub actionsが起動する。
+
+自動でpep8がチェックされた後にはlintされた結果が出てくる。
+
+```
+| --- original/./connect_Raspi/comp.py
+| +++ fixed/./connect_Raspi/comp.py
+| @@ -20,61 +20,61 @@
+|  # pin used in LED flush
+|  GPIO.setup(12, GPIO.OUT)
+|  
+| -tmptime=30.0
+| +tmptime = 30.0
+|  
+|  MUSICDIR = "/home/pi/akabeko_headban/music/"
+|  
+|  
+|  try:
+|      while True:
+| -        if GPIO.input(20) == True:
+| +        if GPIO.input(20):
+|              game.init()
+|              game.music.load(MUSICDIR + 'akabeko1.mp3')
+|              game.music.play(1)
+|              GPIO.output(23, True)
+| -            intime=time.time()
+| -            nowtime=intime
+| +            intime = time.time()
+| +            nowtime = intime
+|  
+```
+
+`-` で示されている行で lint に失敗しているため `+` で示されているように変更する必要がある。
+
+これでエラーが出ないように変更すれば実際に push して OK! 開発の補助にお役立て下さい！

--- a/connect_Raspi/comp.py
+++ b/connect_Raspi/comp.py
@@ -20,61 +20,61 @@ GPIO.setup(17, GPIO.OUT)
 # pin used in LED flush
 GPIO.setup(12, GPIO.OUT)
 
-tmptime=30.0
+tmptime = 30.0
 
 MUSICDIR = "/home/pi/akabeko_headban/music/"
 
 
 try:
     while True:
-        if GPIO.input(20) == True:
+        if GPIO.input(20):
             game.init()
             game.music.load(MUSICDIR + 'akabeko1.mp3')
             game.music.play(1)
             GPIO.output(23, True)
-            intime=time.time()
-            nowtime=intime
+            intime = time.time()
+            nowtime = intime
 
             while nowtime - intime < tmptime:
                 GPIO.output(12, True)
-                time.sleep(60.0/160000*2)
+                time.sleep(60.0 / 160000 * 2)
                 GPIO.output(12, False)
-                time.sleep(60.0/160000*2)
-                nowtime=time.time()
+                time.sleep(60.0 / 160000 * 2)
+                nowtime = time.time()
 
             game.music.stop()
 
-        if GPIO.input(21) == True:
+        if GPIO.input(21):
             game.init()
             game.music.load(MUSICDIR + 'akabeko2.mp3')
             game.music.play(1)
             GPIO.output(18, True)
-            intime=time.time()
-            nowtime=intime
+            intime = time.time()
+            nowtime = intime
 
             while nowtime - intime < tmptime:
                 GPIO.output(12, True)
-                time.sleep(116.0/160000*2)
+                time.sleep(116.0 / 160000 * 2)
                 GPIO.output(12, False)
-                time.sleep(116.0/160000*2)
-                nowtime=time.time()
+                time.sleep(116.0 / 160000 * 2)
+                nowtime = time.time()
 
             game.music.stop()
 
-        if GPIO.input(24) == True:
+        if GPIO.input(24):
             game.init()
-            game.music.load(MUSICDIR+'akabeko3145.mp3')
+            game.music.load(MUSICDIR + 'akabeko3145.mp3')
             game.music.play(1)
             GPIO.output(17, True)
-            intime=time.time()
-            nowtime=intime
+            intime = time.time()
+            nowtime = intime
 
             while nowtime - intime < tmptime:
                 GPIO.output(12, True)
-                time.sleep(145.0/160000)
+                time.sleep(145.0 / 160000)
                 GPIO.output(12, False)
-                time.sleep(145.0/160000)
-                nowtime=time.time()
+                time.sleep(145.0 / 160000)
+                nowtime = time.time()
 
             game.music.stop()
         else:


### PR DESCRIPTION
Linterとして PEP8 を入れたい。
強制的にチェックしてコーディングスタイルの統一を図ることが目的です。